### PR TITLE
Transition to Spicetify Platform APIs

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { combinePlaylists, getPlaylistInfo, getPaginatedSpotifyData, TrackState, setCombinedPlaylistsSettings, getCombinedPlaylistsSettings } from './utils';
-import { CREATE_NEW_PLAYLIST_IDENTIFIER, CREATE_PLAYLIST_URL, GET_PLAYLISTS_URL, LIKED_SONGS_PLAYLIST_FACADE, LS_KEY } from './constants';
+import { getAllPlaylists, combinePlaylists, getPlaylistInfo, TrackState, setCombinedPlaylistsSettings, getCombinedPlaylistsSettings } from './utils';
+import { CREATE_NEW_PLAYLIST_IDENTIFIER, LIKED_SONGS_PLAYLIST_FACADE, LS_KEY } from './constants';
 import type { CombinedPlaylist, SpotifyPlaylist, InitialPlaylistForm, CombinedPlaylistsSettings } from './types';
 
 import './assets/css/styles.scss';
@@ -50,7 +50,7 @@ class App extends React.Component<Record<string, unknown>, State> {
 
    @TrackState('isInitializing')
    async componentDidMount() {
-      const playlists = [...await getPaginatedSpotifyData<SpotifyPlaylist>(GET_PLAYLISTS_URL), LIKED_SONGS_PLAYLIST_FACADE];
+      const playlists = [...await getAllPlaylists(), LIKED_SONGS_PLAYLIST_FACADE];
       const combinedPlaylists = this.combinedPlaylistsLs.map((combinedPlaylist) => this.getMostRecentPlaylistFromData(combinedPlaylist, playlists));
       const checkedCombinedPlaylists = this.checkIfPlaylistsAreStillValid(combinedPlaylists);
 
@@ -92,11 +92,10 @@ class App extends React.Component<Record<string, unknown>, State> {
    }
 
    async createPlaylist(sources: string[]) {
-      const { username }: { username: string } = await Spicetify.Platform.UserAPI.getUser();
       const sourcePlaylistNames = sources.map((source) => this.findPlaylist(source).name);
 
-      const newPlaylist = await Spicetify.CosmosAsync.post(CREATE_PLAYLIST_URL(username), {
-         name: 'Combined Playlist',
+      const newPlaylist = await Spicetify.Platform.RootlistAPI.createPlaylist('Combined Playlist', {
+         before: 'start',
          description: `Combined playlist from ${sourcePlaylistNames.join(', ')}.`,
          public: false,
       });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -94,11 +94,16 @@ class App extends React.Component<Record<string, unknown>, State> {
    async createPlaylist(sources: string[]) {
       const sourcePlaylistNames = sources.map((source) => this.findPlaylist(source).name);
 
-      const newPlaylist = await Spicetify.Platform.RootlistAPI.createPlaylist('Combined Playlist', {
+      const uri = await Spicetify.Platform.RootlistAPI.createPlaylist('Combined Playlist', {
          before: 'start',
-         description: `Combined playlist from ${sourcePlaylistNames.join(', ')}.`,
-         public: false,
       });
+      let newPlaylist = {uri : uri};
+
+      const playlistUri = `spotify:playlist:${newPlaylist.uri.split(':')[2]}`;
+
+      // Set description and make playlist private
+      await Spicetify.Platform.PlaylistAPI.setAttributes(playlistUri, { description: `Combined playlist from ${sourcePlaylistNames.join(', ')}.` });
+      await Spicetify.Platform.PlaylistPermissionsAPI.setBasePermission(newPlaylist.uri, "BLOCKED");
 
       this.setState((state) => ({ playlists: [...state.playlists, newPlaylist ] }));
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,11 +1,7 @@
 import { SpotifyPlaylist } from '../types';
 
-export const GET_PLAYLISTS_URL = 'https://api.spotify.com/v1/me/playlists?limit=50';
-
 export const LS_KEY = 'combined-playlists';
 export const LS_KEY_SETTINGS = 'combined-playlists-settings';
-
-export const CREATE_PLAYLIST_URL = (userId: string) => `https://api.spotify.com/v1/users/${userId}/playlists`;
 
 export const CREATE_NEW_PLAYLIST_IDENTIFIER = 'CREATE_NEW_PLAYLIST_IDENTIFIER';
 

--- a/src/utils/combine-playlists.ts
+++ b/src/utils/combine-playlists.ts
@@ -44,7 +44,7 @@ export async function combinePlaylists(sourcePlaylists: PlaylistInfo[], targetPl
 }
 
 export function addTracksToPlaylist(playlistUri: string, trackUris: string[]): Promise<void> {
-   return Spicetify.Platform.PlaylistAPI.add(playlistUri, trackUris, {});
+   return Spicetify.Platform.PlaylistAPI.add(playlistUri, trackUris, { after: "end" });
 }
 
 async function getPlaylistTracksWithCache(uri: string) {

--- a/src/utils/get-all-playlists.ts
+++ b/src/utils/get-all-playlists.ts
@@ -1,0 +1,28 @@
+import { SpotifyPlaylist } from '../types';
+
+function processPlaylists(items: any[]): SpotifyPlaylist[] {
+    const playlists: SpotifyPlaylist[] = [];
+
+    for (const item of items) {
+        if (item.type === 'playlist') {
+            const { URI } = Spicetify;
+            const uri = URI.from(item.uri);
+            if (uri?.id) {
+                playlists.push({
+                    ...item,
+                    id: uri.id,
+                } as SpotifyPlaylist);
+            }
+        } else if (item.type === 'folder' && item.items) {
+            playlists.push(...processPlaylists(item.items));
+        }
+    }
+
+    return playlists;
+}
+
+
+export async function getAllPlaylists(): Promise<SpotifyPlaylist[]> {
+   const rootlist = await Spicetify.Platform.RootlistAPI.getContents();
+   return processPlaylists(rootlist.items);
+}

--- a/src/utils/get-paginated-spotify-data.ts
+++ b/src/utils/get-paginated-spotify-data.ts
@@ -1,8 +1,0 @@
-export async function getPaginatedSpotifyData<T>(url: string): Promise<T[]> {
-   const res: SpotifyApi.PagingObject<T> = await Spicetify.CosmosAsync.get(url);
-
-   return [
-      ...res.items,
-      ...(res.next ? await getPaginatedSpotifyData<T>(res.next) : []),
-   ];
-}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export * from './combine-playlists';
-export * from './get-paginated-spotify-data';
+export * from './get-all-playlists';
 export * from './get-playlist-info';
 export * from './split-array-in-chunks';
 export * from './track-state';


### PR DESCRIPTION
Avoids the 429 errors causing the extension to be completely unusable 

Fixes #32 