### PR TITLE
feat: replace source playlist dropdowns with checkbox list and folder…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "formik": "^2.4.6",
-        "semver": "^7.6.3"
+        "semver": "^7.6.3",
+        "string-similarity-js": "^2.1.4"
       },
       "devDependencies": {
         "@eslint/compat": "^1.4.1",
@@ -5439,6 +5440,12 @@
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/string-similarity-js": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/string-similarity-js/-/string-similarity-js-2.1.4.tgz",
+      "integrity": "sha512-uApODZNjCHGYROzDSAdCmAHf60L/pMDHnP/yk6TAbvGg7JSPZlSto/ceCI7hZEqzc53/juU2aOJFkM2yUVTMTA==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "combined-playlists",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "combined-playlists",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "formik": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "formik": "^2.4.6",
-    "semver": "^7.6.3"
+    "semver": "^7.6.3",
+    "string-similarity-js": "^2.1.4"
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,22 +1,30 @@
 import React from 'react';
-import { getAllPlaylists, getAllPlaylistItems, combinePlaylists, getPlaylistInfo, TrackState, setCombinedPlaylistsSettings, getCombinedPlaylistsSettings } from './utils';
-import type { RootlistPlaylist, RootListItems } from './utils';
-import { CREATE_NEW_PLAYLIST_IDENTIFIER, LIKED_SONGS_PLAYLIST_FACADE, LS_KEY } from './constants';
-import type { CombinedPlaylist, InitialPlaylistForm, CombinedPlaylistsSettings } from './types';
+import {
+   combinePlaylists,
+   getCombinedPlaylistsSettings,
+   getPlaylistInfo,
+   getPlaylists,
+   processPlaylists,
+   RootListItems,
+   RootlistPlaylist,
+   setCombinedPlaylistsSettings,
+   TrackState
+} from './utils';
+import {CREATE_NEW_PLAYLIST_IDENTIFIER, LIKED_SONGS_PLAYLIST_FACADE, LS_KEY} from './constants';
+import type {CombinedPlaylist, CombinedPlaylistsSettings, InitialPlaylistForm} from './types';
 
 import './assets/css/styles.scss';
-import { SpicetifySvgIcon } from './components/SpicetifySvgIcon';
-import { PlaylistForm } from './components/AddPlaylistForm';
-import { AddPlaylistCard } from './components/AddPlaylistCard';
-import { Card } from './components/Card';
-import { ImportExportModal } from './components/ImportExportModal';
-import { synchronizeCombinedPlaylists } from './extensions/auto-sync';
-import { UpdateBanner } from './components/UpdateBanner';
-import { ConfirmDialog } from './components/ConfirmDialog';
-import { addIdFromUri } from './utils/add-id-from-uri';
+import {SpicetifySvgIcon} from './components/SpicetifySvgIcon';
+import {PlaylistForm} from './components/AddPlaylistForm';
+import {AddPlaylistCard} from './components/AddPlaylistCard';
+import {Card} from './components/Card';
+import {ImportExportModal} from './components/ImportExportModal';
+import {synchronizeCombinedPlaylists} from './extensions/auto-sync';
+import {UpdateBanner} from './components/UpdateBanner';
+import {ConfirmDialog} from './components/ConfirmDialog';
+import {addIdFromUri} from './utils/add-id-from-uri';
 
 export interface State {
-   playlists: RootlistPlaylist[];
    playlistItems: RootListItems[];
    combinedPlaylists: CombinedPlaylist[];
    isLoading: boolean;
@@ -37,13 +45,16 @@ class App extends React.Component<Record<string, unknown>, State> {
       Spicetify.LocalStorage.set(LS_KEY, JSON.stringify(playlists));
    }
 
+   get flattenedPlaylists(): RootlistPlaylist[] {
+      return processPlaylists(this.state.playlistItems);
+   }
+
    constructor(props: Record<string, unknown>) {
       super(props);
 
       const settings = getCombinedPlaylistsSettings();
 
       this.state = {
-         playlists: [],
          playlistItems: [],
          combinedPlaylists: [],
          isLoading: false,
@@ -54,14 +65,13 @@ class App extends React.Component<Record<string, unknown>, State> {
 
    @TrackState('isInitializing')
    async componentDidMount() {
-      const [rawPlaylists, rawPlaylistItems] = await Promise.all([getAllPlaylists(), getAllPlaylistItems()]);
+      const [rawPlaylists, rawPlaylistItems] = await Promise.all([getPlaylists(true), getPlaylists()]);
       const playlists = [...rawPlaylists, LIKED_SONGS_PLAYLIST_FACADE];
       const playlistItems = [...rawPlaylistItems, LIKED_SONGS_PLAYLIST_FACADE];
       const combinedPlaylists = this.combinedPlaylistsLs.map((combinedPlaylist) => this.getMostRecentPlaylistFromData(combinedPlaylist, playlists));
       const checkedCombinedPlaylists = this.checkIfPlaylistsAreStillValid(combinedPlaylists);
 
       this.setState({
-         playlists,
          playlistItems,
          combinedPlaylists: checkedCombinedPlaylists
       });
@@ -116,7 +126,7 @@ class App extends React.Component<Record<string, unknown>, State> {
       const playlist: RootlistPlaylist = await Spicetify.Platform.RootlistAPI.getContents()
          .then((contents: { items: RootListItems[] }) => contents.items.find((item) => item.uri === newPlaylistUri))
          .then((playlist: RootlistPlaylist) => addIdFromUri(playlist));
-      this.setState((state) => ({ playlists: [...state.playlists, playlist ] }));
+      this.setState((state) => ({ playlistItems: [...state.playlistItems, playlist ] }));
 
       console.log('new playlist', playlist);
 
@@ -199,7 +209,7 @@ class App extends React.Component<Record<string, unknown>, State> {
    }
 
    findPlaylist(id: string) {
-      return this.state.playlists.find((playlist) => playlist.id === id) as RootlistPlaylist;
+      return this.flattenedPlaylists.find((playlist) => playlist.id === id) as RootlistPlaylist;
    }
 
    getMostRecentPlaylistFromData(combinedPlaylist: CombinedPlaylist, playlists: RootlistPlaylist[]): CombinedPlaylist {
@@ -210,7 +220,7 @@ class App extends React.Component<Record<string, unknown>, State> {
    }
 
    showAddPlaylistModal() {
-      const Form = <PlaylistForm playlists={this.state.playlists} playlistItems={this.state.playlistItems} onSubmit={this.createNewCombinedPlaylist.bind(this)} />;
+      const Form = <PlaylistForm playlists={this.flattenedPlaylists} playlistItems={this.state.playlistItems} onSubmit={this.createNewCombinedPlaylist.bind(this)} />;
 
       Spicetify.PopupModal.display({
          title: 'Create combined playlist',
@@ -225,7 +235,7 @@ class App extends React.Component<Record<string, unknown>, State> {
          sources: combinedPlaylist.sources.map((source) => source.id)
       };
       const Form = <PlaylistForm
-         playlists={this.state.playlists}
+         playlists={this.flattenedPlaylists}
          playlistItems={this.state.playlistItems}
          onSubmit={this.createNewCombinedPlaylist.bind(this)}
          onDelete={() => {
@@ -246,7 +256,7 @@ class App extends React.Component<Record<string, unknown>, State> {
    openImportExportModal() {
       const importCombinedPlaylists = (combinedPlaylistsData: string) => {
          const combinedPlaylists = JSON.parse(combinedPlaylistsData);
-         const safeCombinedPlaylists = this.checkIfPlaylistsAreStillValid(combinedPlaylists.map((combinedPlaylist: CombinedPlaylist) => this.getMostRecentPlaylistFromData(combinedPlaylist, this.state.playlists)));
+         const safeCombinedPlaylists = this.checkIfPlaylistsAreStillValid(combinedPlaylists.map((combinedPlaylist: CombinedPlaylist) => this.getMostRecentPlaylistFromData(combinedPlaylist, this.flattenedPlaylists)));
 
          this.setState({ combinedPlaylists: safeCombinedPlaylists });
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getAllPlaylists, combinePlaylists, getPlaylistInfo, TrackState, setCombinedPlaylistsSettings, getCombinedPlaylistsSettings } from './utils';
+import { getAllPlaylists, getAllPlaylistItems, combinePlaylists, getPlaylistInfo, TrackState, setCombinedPlaylistsSettings, getCombinedPlaylistsSettings } from './utils';
 import type { RootlistPlaylist, RootListItems } from './utils';
 import { CREATE_NEW_PLAYLIST_IDENTIFIER, LIKED_SONGS_PLAYLIST_FACADE, LS_KEY } from './constants';
 import type { CombinedPlaylist, InitialPlaylistForm, CombinedPlaylistsSettings } from './types';
@@ -17,6 +17,7 @@ import { addIdFromUri } from './utils/add-id-from-uri';
 
 export interface State {
    playlists: RootlistPlaylist[];
+   playlistItems: RootListItems[];
    combinedPlaylists: CombinedPlaylist[];
    isLoading: boolean;
    isInitializing: boolean;
@@ -43,6 +44,7 @@ class App extends React.Component<Record<string, unknown>, State> {
 
       this.state = {
          playlists: [],
+         playlistItems: [],
          combinedPlaylists: [],
          isLoading: false,
          isInitializing: false,
@@ -52,12 +54,15 @@ class App extends React.Component<Record<string, unknown>, State> {
 
    @TrackState('isInitializing')
    async componentDidMount() {
-      const playlists = [...await getAllPlaylists(), LIKED_SONGS_PLAYLIST_FACADE];
+      const [rawPlaylists, rawPlaylistItems] = await Promise.all([getAllPlaylists(), getAllPlaylistItems()]);
+      const playlists = [...rawPlaylists, LIKED_SONGS_PLAYLIST_FACADE];
+      const playlistItems = [...rawPlaylistItems, LIKED_SONGS_PLAYLIST_FACADE];
       const combinedPlaylists = this.combinedPlaylistsLs.map((combinedPlaylist) => this.getMostRecentPlaylistFromData(combinedPlaylist, playlists));
       const checkedCombinedPlaylists = this.checkIfPlaylistsAreStillValid(combinedPlaylists);
 
       this.setState({
          playlists,
+         playlistItems,
          combinedPlaylists: checkedCombinedPlaylists
       });
 
@@ -205,7 +210,7 @@ class App extends React.Component<Record<string, unknown>, State> {
    }
 
    showAddPlaylistModal() {
-      const Form = <PlaylistForm playlists={this.state.playlists} onSubmit={this.createNewCombinedPlaylist.bind(this)} />;
+      const Form = <PlaylistForm playlists={this.state.playlists} playlistItems={this.state.playlistItems} onSubmit={this.createNewCombinedPlaylist.bind(this)} />;
 
       Spicetify.PopupModal.display({
          title: 'Create combined playlist',
@@ -221,6 +226,7 @@ class App extends React.Component<Record<string, unknown>, State> {
       };
       const Form = <PlaylistForm
          playlists={this.state.playlists}
+         playlistItems={this.state.playlistItems}
          onSubmit={this.createNewCombinedPlaylist.bind(this)}
          onDelete={() => {
             Spicetify.PopupModal.hide();

--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -156,15 +156,66 @@
   display: flex;
   flex-direction: column;
 
-  .select-wrapper {
-    display: flex;
-    gap: 1em;
-    padding: 8px 0;
-    align-items: center;
+  .source-playlist-list {
+    max-height: 280px;
+    overflow-y: auto;
+    border: 1px solid var(--spice-misc);
+    border-radius: 6px;
+    padding: 4px;
+    margin-bottom: 1rem;
+  }
 
-    button {
-      display: flex;
+  .source-playlist-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 5px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    user-select: none;
+
+    &:hover {
+      background-color: var(--spice-highlight-elevated);
     }
+
+    input[type="checkbox"] {
+      cursor: pointer;
+      accent-color: var(--spice-button);
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+  }
+
+  .source-folder-group {
+    margin-bottom: 2px;
+  }
+
+  .source-folder-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 5px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    user-select: none;
+    font-weight: 600;
+
+    &:hover {
+      background-color: var(--spice-highlight-elevated);
+    }
+
+    input[type="checkbox"] {
+      cursor: pointer;
+      accent-color: var(--spice-button);
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+  }
+
+  .source-folder-items {
+    padding-left: 26px;
   }
 
   #target-select-field {

--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -157,7 +157,7 @@
   flex-direction: column;
 
   .source-playlist-list {
-    max-height: 280px;
+    max-height: 40em;
     overflow-y: auto;
     border: 1px solid var(--spice-misc);
     border-radius: 6px;
@@ -220,6 +220,37 @@
 
   #target-select-field {
     margin: 16px 0;
+  }
+
+  #search-input {
+    margin-top: 0.5em;
+    margin-bottom: 1em;
+  }
+
+  #search-input, #target-select-field {
+    height: auto;
+    font-size: 1.1em;
+    padding: 12px;
+  }
+
+  .selected-playlists {
+    margin-top: 1em;
+    margin-bottom: 2rem;
+
+    h4 {
+      margin-bottom: 0.5rem;
+      font-size: 1rem;
+    }
+
+    ul {
+      padding-left: 1.5rem;
+      margin-bottom: 1em;
+      list-style: disc;
+
+      li {
+        margin-bottom: 0.25rem;
+      }
+    }
   }
 
   .error-msg {

--- a/src/components/AddPlaylistForm.tsx
+++ b/src/components/AddPlaylistForm.tsx
@@ -1,9 +1,10 @@
-import { Formik, Form, ErrorMessage } from 'formik';
-import React, { useRef, useEffect } from 'react';
-import type { InitialPlaylistForm } from '../types/initial-playlist-form';
-import { CREATE_NEW_PLAYLIST_IDENTIFIER } from '../constants';
-import { TrashIcon } from './TrashIcon';
-import type { RootlistPlaylist, RootListItems, Folder } from '../utils';
+import {ErrorMessage, Form, Formik} from 'formik';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
+import stringSimilarity from 'string-similarity-js';
+import type {InitialPlaylistForm} from '../types/initial-playlist-form';
+import {CREATE_NEW_PLAYLIST_IDENTIFIER} from '../constants';
+import {TrashIcon} from './TrashIcon';
+import type {Folder, RootListItems, RootlistPlaylist} from '../utils';
 
 interface Props {
    playlists: RootlistPlaylist[];
@@ -90,6 +91,48 @@ function FolderItem({ folder, sources, onTogglePlaylist, onToggleFolder }: Folde
 }
 
 export function PlaylistForm({ playlists, playlistItems, onSubmit, onDelete, initialForm = defaultForm, isNew = true }: Props) {
+   const [searchQuery, setSearchQuery] = useState('');
+
+   const filterItems = (items: RootListItems[], query: string): RootListItems[] => {
+      if (!query.trim()) return items;
+      const lowerQuery = query.toLowerCase().trim();
+      return items.reduce<RootListItems[]>((acc, item) => {
+         if (item.type === 'playlist') {
+            if (item.name.toLowerCase().includes(lowerQuery)) {
+               acc.push(item);
+            }
+         } else if (item.type === 'folder') {
+            const folderSimilarity = stringSimilarity(item.name.toLowerCase(), lowerQuery);
+            if (folderSimilarity >= 0.7) {
+               acc.push(item); // include whole folder
+            } else {
+               const filteredSubItems = filterItems(item.items, query);
+               if (filteredSubItems.length > 0) {
+                  acc.push({ ...item, items: filteredSubItems });
+               }
+            }
+         }
+         return acc;
+      }, []);
+   };
+
+   const filteredPlaylistItems = useMemo(() => filterItems(playlistItems, searchQuery), [playlistItems, searchQuery]);
+
+   const playlistNameMap = useMemo(() => {
+      const map = new Map<string, string>();
+      const addToMap = (items: RootListItems[]) => {
+         items.forEach((item) => {
+            if (item.type === 'playlist') {
+               map.set(item.id, item.name);
+            } else if (item.type === 'folder') {
+               addToMap(item.items);
+            }
+         });
+      };
+      addToMap(playlistItems);
+      return map;
+   }, [playlistItems]);
+
    const validationFn = (form: InitialPlaylistForm) => {
       const errors: Record<string, unknown> = {};
       if (form.sources.length === 0) errors.sources = 'Select at least one source playlist';
@@ -125,10 +168,18 @@ export function PlaylistForm({ playlists, playlistItems, onSubmit, onDelete, ini
 
             return (
                <Form id="create-combined-playlist-form">
+                  <h3>Source playlists</h3>
+                  <input
+                     type="text"
+                     placeholder="Search playlists..."
+                     value={searchQuery}
+                     onChange={(e) => setSearchQuery(e.target.value)}
+                     className="main-dropDown-dropDown"
+                     id="search-input"
+                  />
                   <fieldset disabled={isSubmitting}>
-                     <h3>Source playlists</h3>
                      <div className="source-playlist-list">
-                        {playlistItems.map((item) => {
+                        {filteredPlaylistItems.map((item) => {
                            if (item.type === 'playlist') {
                               return (
                                  <label key={item.id} className="source-playlist-item">
@@ -151,6 +202,16 @@ export function PlaylistForm({ playlists, playlistItems, onSubmit, onDelete, ini
                            return null;
                         })}
                      </div>
+                     {values.sources.length > 0 && (
+                        <div className="selected-playlists">
+                           <h4>Selected Playlists</h4>
+                           <ul>
+                              {values.sources.map(id => (
+                                 <li key={id}>{playlistNameMap.get(id) || id}</li>
+                              ))}
+                           </ul>
+                        </div>
+                     )}
                      <ErrorMsg name="sources" />
 
                      <h3>Target playlist</h3>

--- a/src/components/AddPlaylistForm.tsx
+++ b/src/components/AddPlaylistForm.tsx
@@ -1,129 +1,191 @@
-import { Formik, Form, FieldArray, Field, ErrorMessage } from 'formik';
-import type { FieldArrayRenderProps } from 'formik';
-import React from 'react';
-import { SpicetifySvgIcon } from './SpicetifySvgIcon';
+import { Formik, Form, ErrorMessage } from 'formik';
+import React, { useRef, useEffect } from 'react';
 import type { InitialPlaylistForm } from '../types/initial-playlist-form';
 import { CREATE_NEW_PLAYLIST_IDENTIFIER } from '../constants';
 import { TrashIcon } from './TrashIcon';
-import { RootlistPlaylist } from '../utils';
+import type { RootlistPlaylist, RootListItems, Folder } from '../utils';
 
 interface Props {
    playlists: RootlistPlaylist[];
+   playlistItems: RootListItems[];
    onSubmit: SubmitEventHandler;
    onDelete?: DeleteEventHandler;
    initialForm?: InitialPlaylistForm;
    isNew?: boolean;
 }
 
-export type SubmitEventHandler = (form : InitialPlaylistForm) => void;
+export type SubmitEventHandler = (form: InitialPlaylistForm) => void;
 export type DeleteEventHandler = () => void;
 
-const initialPlaylistForm: InitialPlaylistForm = {
+const defaultForm: InitialPlaylistForm = {
    target: CREATE_NEW_PLAYLIST_IDENTIFIER,
-   sources: ['', '']
+   sources: []
 };
 
-export function PlaylistForm({ playlists, onSubmit, onDelete, initialForm = initialPlaylistForm, isNew = true }: Props) {
+function getFolderPlaylistIds(folder: Folder): string[] {
+   return folder.items.flatMap(item => {
+      if (item.type === 'playlist') return [item.id];
+      if (item.type === 'folder') return getFolderPlaylistIds(item);
+      return [];
+   });
+}
 
+function IndeterminateCheckbox({ checked, indeterminate, onChange }: { checked: boolean; indeterminate: boolean; onChange: () => void }) {
+   const ref = useRef<HTMLInputElement>(null);
+   useEffect(() => {
+      if (ref.current) ref.current.indeterminate = indeterminate;
+   }, [indeterminate]);
+   return <input type="checkbox" ref={ref} checked={checked} onChange={onChange} />;
+}
+
+interface FolderItemProps {
+   folder: Folder;
+   sources: string[];
+   onTogglePlaylist: (id: string) => void;
+   onToggleFolder: (folder: Folder) => void;
+}
+
+function FolderItem({ folder, sources, onTogglePlaylist, onToggleFolder }: FolderItemProps) {
+   const folderIds = getFolderPlaylistIds(folder);
+   const selectedCount = folderIds.filter(id => sources.includes(id)).length;
+   const allSelected = folderIds.length > 0 && selectedCount === folderIds.length;
+   const someSelected = selectedCount > 0 && !allSelected;
+
+   return (
+      <div className="source-folder-group">
+         <label className="source-folder-header">
+            <IndeterminateCheckbox
+               checked={allSelected}
+               indeterminate={someSelected}
+               onChange={() => onToggleFolder(folder)}
+            />
+            <span className="source-folder-name">{folder.name}</span>
+         </label>
+         <div className="source-folder-items">
+            {folder.items.map((item) => {
+               if (item.type === 'playlist') {
+                  return (
+                     <label key={item.id} className="source-playlist-item">
+                        <input type="checkbox" checked={sources.includes(item.id)} onChange={() => onTogglePlaylist(item.id)} />
+                        <span>{item.name}</span>
+                     </label>
+                  );
+               }
+               if (item.type === 'folder') {
+                  return (
+                     <FolderItem
+                        key={item.uri}
+                        folder={item}
+                        sources={sources}
+                        onTogglePlaylist={onTogglePlaylist}
+                        onToggleFolder={onToggleFolder}
+                     />
+                  );
+               }
+               return null;
+            })}
+         </div>
+      </div>
+   );
+}
+
+export function PlaylistForm({ playlists, playlistItems, onSubmit, onDelete, initialForm = defaultForm, isNew = true }: Props) {
    const validationFn = (form: InitialPlaylistForm) => {
       const errors: Record<string, unknown> = {};
-
-      if (form.sources.every((source) => !source)) errors.sources = 'Select at least on source playlist';
+      if (form.sources.length === 0) errors.sources = 'Select at least one source playlist';
       if (!form.target) errors.target = 'Select a target playlist';
-
       return errors;
    };
 
-   let sourcesFieldHelpers: FieldArrayRenderProps; // TODO find a cleaner way to handle this..
-
-   const ErrorMsg = (props: { name: string }) => (<ErrorMessage name={props.name}>{msg => <div className="error-msg">{msg}</div>}</ErrorMessage>);
+   const ErrorMsg = ({ name }: { name: string }) => (
+      <ErrorMessage name={name}>{msg => <div className="error-msg">{msg}</div>}</ErrorMessage>
+   );
 
    return (
-      <Formik
-         initialValues={initialForm}
-         onSubmit={onSubmit}
-         validate={validationFn}
-      >
-         {({ values, isSubmitting }) => (
-            <Form id="create-combined-playlist-form">
-               <fieldset disabled={isSubmitting}>
-                  <h3>Source playlists</h3>
-                  <FieldArray name="sources">
-                     {(arrayHelpers) => {
-                        sourcesFieldHelpers = arrayHelpers;
+      <Formik initialValues={initialForm} onSubmit={onSubmit} validate={validationFn}>
+         {({ values, setFieldValue, isSubmitting }) => {
+            const togglePlaylist = (id: string) => {
+               if (values.sources.includes(id)) {
+                  setFieldValue('sources', values.sources.filter(s => s !== id));
+               } else {
+                  setFieldValue('sources', [...values.sources, id]);
+               }
+            };
 
-                        return (
-                           <div style={{ 'marginBottom': '1rem' }}>
-                              {values.sources && values.sources.length > 0 ? (
-                                 values.sources.map((_source, index) => (
-                                    <div key={index} className="select-wrapper">
-                                       <Field as="select" name={`sources.${index}`} className="main-dropDown-dropDown">
-                                          <option value="">Select a source playlist</option>
-                                          { playlists.map(({ id, name }) => (
-                                             <option key={id} value={id}>{name}</option>
-                                          )) }
-                                       </Field>
+            const toggleFolder = (folder: Folder) => {
+               const folderIds = getFolderPlaylistIds(folder);
+               const allSelected = folderIds.every(id => values.sources.includes(id));
+               if (allSelected) {
+                  setFieldValue('sources', values.sources.filter(id => !folderIds.includes(id)));
+               } else {
+                  const toAdd = folderIds.filter(id => !values.sources.includes(id));
+                  setFieldValue('sources', [...values.sources, ...toAdd]);
+               }
+            };
 
-                                       {values.sources.length > 1 && <button
-                                          className='main-buttons-button main-button-outlined btn__remove-playlist'
-                                          type="button"
-                                          onClick={(e) => {
-                                             e.preventDefault();
-                                             e.stopPropagation();
-                                             arrayHelpers.remove(index);
-                                          }}
-                                          name="Remove playlist"
-                                       >
-                                          <SpicetifySvgIcon iconName="x" size={16} />
-                                       </button>}
-                                    </div>
-                                 ))
-                              ) : null}
-                           </div>
-                        );
-                     }}
-                  </FieldArray>
-                  <ErrorMsg name="sources" />
+            return (
+               <Form id="create-combined-playlist-form">
+                  <fieldset disabled={isSubmitting}>
+                     <h3>Source playlists</h3>
+                     <div className="source-playlist-list">
+                        {playlistItems.map((item) => {
+                           if (item.type === 'playlist') {
+                              return (
+                                 <label key={item.id} className="source-playlist-item">
+                                    <input type="checkbox" checked={values.sources.includes(item.id)} onChange={() => togglePlaylist(item.id)} />
+                                    <span>{item.name}</span>
+                                 </label>
+                              );
+                           }
+                           if (item.type === 'folder') {
+                              return (
+                                 <FolderItem
+                                    key={item.uri}
+                                    folder={item}
+                                    sources={values.sources}
+                                    onTogglePlaylist={togglePlaylist}
+                                    onToggleFolder={toggleFolder}
+                                 />
+                              );
+                           }
+                           return null;
+                        })}
+                     </div>
+                     <ErrorMsg name="sources" />
 
-                  <h3>Target playlist</h3>
-                  <Field
-                     as="select"
-                     name="target"
-                     placeholder="Select target playlist"
-                     id="target-select-field"
-                     className="main-dropDown-dropDown"
-                  >
-                     <option value={CREATE_NEW_PLAYLIST_IDENTIFIER}>Create new playlist</option>
-                     { playlists.map(({ id, name }) => (
-                        <option key={id} value={id}>{name}</option>
-                     )) }
-                  </Field>
-                  <ErrorMsg name="target" />
+                     <h3>Target playlist</h3>
+                     <select
+                        name="target"
+                        id="target-select-field"
+                        className="main-dropDown-dropDown"
+                        value={values.target}
+                        onChange={(e) => setFieldValue('target', e.target.value)}
+                     >
+                        <option value={CREATE_NEW_PLAYLIST_IDENTIFIER}>Create new playlist</option>
+                        {playlists.map(({ id, name }) => (
+                           <option key={id} value={id}>{name}</option>
+                        ))}
+                     </select>
+                     <ErrorMsg name="target" />
 
-                  <div id="form-actions-container">
-                     <button
-                        className='main-buttons-button main-button-outlined btn__add-playlist'
-                        type="button"
-                        onClick={() => sourcesFieldHelpers.push('')} // insert an empty string at a position
-                     >Add another playlist</button>
-                     <button type="submit" className="main-buttons-button main-button-outlined">
-                        {isSubmitting ? 'Loading..' : (initialForm.target ? 'Save' : 'Submit')}
-                     </button>
-
-                     { !isNew
-                        ? <button
-                           type="button"
-                           className="main-buttons-button main-button-outlined btn__add-playlist"
-                           onClick={() => onDelete?.()}
-                        >
-                           <TrashIcon />
+                     <div id="form-actions-container">
+                        <button type="submit" className="main-buttons-button main-button-outlined">
+                           {isSubmitting ? 'Loading..' : (isNew ? 'Submit' : 'Save')}
                         </button>
-                        : null
-                     }
-                  </div>
-               </fieldset>
-            </Form>
-         )}
+                        {!isNew && (
+                           <button
+                              type="button"
+                              className="main-buttons-button main-button-outlined btn__add-playlist"
+                              onClick={() => onDelete?.()}
+                           >
+                              <TrashIcon />
+                           </button>
+                        )}
+                     </div>
+                  </fieldset>
+               </Form>
+            );
+         }}
       </Formik>
    );
 }

--- a/src/utils/get-all-playlists.ts
+++ b/src/utils/get-all-playlists.ts
@@ -33,7 +33,24 @@ function processPlaylists(items: RootListItems[]): RootlistPlaylist[] {
    });
 }
 
+function processItems(items: RootListItems[]): RootListItems[] {
+   return items.reduce<RootListItems[]>((acc, item) => {
+      if (item.type === 'playlist') {
+         const uri = Spicetify.URI.from(item.uri);
+         if (uri?.id) acc.push(addIdFromUri(item));
+      } else if (item.type === 'folder' && item.items) {
+         acc.push({ ...item, items: processItems(item.items) } as Folder);
+      }
+      return acc;
+   }, []);
+}
+
 export async function getAllPlaylists(): Promise<RootlistPlaylist[]> {
    const rootlist = await Spicetify.Platform.RootlistAPI.getContents();
    return processPlaylists(rootlist.items);
+}
+
+export async function getAllPlaylistItems(): Promise<RootListItems[]> {
+   const rootlist = await Spicetify.Platform.RootlistAPI.getContents();
+   return processItems(rootlist.items);
 }

--- a/src/utils/get-all-playlists.ts
+++ b/src/utils/get-all-playlists.ts
@@ -1,4 +1,4 @@
-import { addIdFromUri } from './add-id-from-uri';
+import {addIdFromUri} from './add-id-from-uri';
 
 export type RootListItems = RootlistPlaylist | Folder;
 
@@ -20,7 +20,7 @@ export interface Folder {
    [key: string]: unknown; // Allow other properties
 }
 
-function processPlaylists(items: RootListItems[]): RootlistPlaylist[] {
+export function processPlaylists(items: RootListItems[]): RootlistPlaylist[] {
    return items.flatMap((item) => {
       if (item.type === 'playlist') {
          const uri = Spicetify.URI.from(item.uri);
@@ -45,12 +45,10 @@ function processItems(items: RootListItems[]): RootListItems[] {
    }, []);
 }
 
-export async function getAllPlaylists(): Promise<RootlistPlaylist[]> {
+export async function getPlaylists(): Promise<RootListItems[]>;
+export async function getPlaylists(flat: true): Promise<RootlistPlaylist[]>;
+export async function getPlaylists(flat: false): Promise<RootListItems[]>;
+export async function getPlaylists(flat: boolean = false): Promise<RootListItems[] | RootlistPlaylist[]> {
    const rootlist = await Spicetify.Platform.RootlistAPI.getContents();
-   return processPlaylists(rootlist.items);
-}
-
-export async function getAllPlaylistItems(): Promise<RootListItems[]> {
-   const rootlist = await Spicetify.Platform.RootlistAPI.getContents();
-   return processItems(rootlist.items);
+   return flat ? processPlaylists(rootlist.items) : processItems(rootlist.items);
 }


### PR DESCRIPTION
I went with Sonnet 4.6 and highest effort+thinking. The changes aren't a lot and had a quick look at it myself. Most changes become it now includes options to click a playlist folder. 
 
- Replaced the "Add playlist" button + individual dropdown workflow with a scrollable checkbox list that shows all playlists at once
- Playlists inside folders are now grouped under their folder with an indeterminate checkbox — checking the folder header selects/deselects all playlists inside it
- Nested folders are supported recursively
- Removed the per-row remove button and the "Add another playlist" button since they are no longer needed
- Added getAllPlaylistItems() utility that fetches the rootlist while preserving the folder hierarchy (used to build the checkbox tree)

<img width="641" height="617" alt="Image" src="https://github.com/user-attachments/assets/8aefb82b-7753-4485-9a92-1ea4c713a247" />